### PR TITLE
Remove contribution guidelines section from technical documentation

### DIFF
--- a/TECHNICAL_DOCUMENTATION.md
+++ b/TECHNICAL_DOCUMENTATION.md
@@ -36,15 +36,13 @@ Python Playground is a web application that integrates game logic, a user-friend
 
 ## 8. Setup & Installation
 
-## 9. Contribution Guidelines
-
-## 10. Diagrams
+## 9. Diagrams
 
 - **System Architecture Diagrams**
 - **Data Flow Diagrams**
 - **Visual Aids**
 
-## 11. References
+## 10. References
 
 - **Libraries**
 - **Frameworks**


### PR DESCRIPTION
This PR removes the "9. Contribution Guidelines" section from the technical documentation. Given that the project will remain proprietary, contribution guidelines are not applicable at this stage.